### PR TITLE
One-click heroku deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TodoMVC in Elm - [Try It!](http://evancz.github.io/elm-todomvc)
 
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/srid/elm-todomvc/tree/heroku)
+
 ## Project Structure
 
 All of the Elm code lives in `Todo.elm` and relies on the [elm-html][] library. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TodoMVC in Elm - [Try It!](http://evancz.github.io/elm-todomvc)
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/srid/elm-todomvc/tree/heroku)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 ## Project Structure
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,9 @@
+{
+    "name": "TodoMVC in Elm",
+    "repository": "https://github.com/evancz/elm-todomvc",
+    "env": {
+        "BUILDPACK_URL": "https://github.com/srid/heroku-buildpack-elm.git",
+        "ELM_COMPILE": "elm make Todo.elm",
+        "ELM_STATIC_DIR": "."
+    }
+}


### PR DESCRIPTION
Deploy to Heroku using my custom buildpack. 

This change also adds a deploy button to the README
which anyone (with a Heroku account) can click to directly deploy this
app to Heroku’s free tire.

See how it all looks here -> https://github.com/srid/elm-todomvc/tree/heroku

Two environment settings are required:

* `ELM_COMPILE`: the full command line to build the Elm sources.
* `ELM_STATIC_DIR`: the directory containing all static assets

The buildpack will run a static web server (warp) to serve generated
assets from the static dir. These two environment variables are added
to app.json, so nothing more is required from the user part other than
simply clicking the deploy button.

As a next step, I will be writing a blog post on deploying Elm apps to
Heroku. Having this PR merged would be nice for that.