### PR TITLE
Make whitespace follow style guide

### DIFF
--- a/Todo.elm
+++ b/Todo.elm
@@ -85,49 +85,68 @@ type Action
 update : Action -> Model -> Model
 update action model =
     case action of
-      NoOp -> model
+        NoOp ->
+            model
 
-      Add ->
-          { model |
-              uid <- model.uid + 1,
-              field <- "",
-              tasks <-
-                  if String.isEmpty model.field
-                    then model.tasks
-                    else model.tasks ++ [newTask model.field model.uid]
-          }
+        Add ->
+            { model |
+                uid <- model.uid + 1,
+                field <- "",
+                tasks <-
+                    if String.isEmpty model.field then
+                        model.tasks
+                    else
+                        model.tasks ++ [newTask model.field model.uid]
+            }
 
-      UpdateField str ->
-          { model | field <- str }
+        UpdateField str ->
+            { model | field <- str }
 
-      EditingTask id isEditing ->
-          let updateTask t = if t.id == id then { t | editing <- isEditing } else t
-          in
-              { model | tasks <- List.map updateTask model.tasks }
+        EditingTask id isEditing ->
+            let
+                updateTask t =
+                    if t.id == id then
+                        { t | editing <- isEditing }
+                    else
+                        t
+            in
+                { model | tasks <- List.map updateTask model.tasks }
 
-      UpdateTask id task ->
-          let updateTask t = if t.id == id then { t | description <- task } else t
-          in
-              { model | tasks <- List.map updateTask model.tasks }
+        UpdateTask id task ->
+            let
+                updateTask t =
+                    if t.id == id then
+                        { t | description <- task }
+                    else
+                        t
+            in
+                { model | tasks <- List.map updateTask model.tasks }
 
-      Delete id ->
-          { model | tasks <- List.filter (\t -> t.id /= id) model.tasks }
+        Delete id ->
+            { model | tasks <- List.filter (\t -> t.id /= id) model.tasks }
 
-      DeleteComplete ->
-          { model | tasks <- List.filter (not << .completed) model.tasks }
+        DeleteComplete ->
+            { model | tasks <- List.filter (not << .completed) model.tasks }
 
-      Check id isCompleted ->
-          let updateTask t = if t.id == id then { t | completed <- isCompleted } else t
-          in
-              { model | tasks <- List.map updateTask model.tasks }
+        Check id isCompleted ->
+            let
+                updateTask t =
+                    if t.id == id then
+                        { t | completed <- isCompleted }
+                    else
+                        t
+            in
+                { model | tasks <- List.map updateTask model.tasks }
 
-      CheckAll isCompleted ->
-          let updateTask t = { t | completed <- isCompleted }
-          in
-              { model | tasks <- List.map updateTask model.tasks }
+        CheckAll isCompleted ->
+            let
+                updateTask t =
+                    { t | completed <- isCompleted }
+            in
+                { model | tasks <- List.map updateTask model.tasks }
 
-      ChangeVisibility visibility ->
-          { model | visibility <- visibility }
+        ChangeVisibility visibility ->
+            { model | visibility <- visibility }
 
 
 ---- VIEW ----
@@ -135,17 +154,17 @@ update action model =
 view : Address Action -> Model -> Html
 view address model =
     div
-      [ class "todomvc-wrapper"
-      , style [ ("visibility", "hidden") ]
-      ]
-      [ section
-          [ id "todoapp" ]
-          [ lazy2 taskEntry address model.field
-          , lazy3 taskList address model.visibility model.tasks
-          , lazy3 controls address model.visibility model.tasks
-          ]
-      , infoFooter
-      ]
+        [ class "todomvc-wrapper"
+        , style [ ("visibility", "hidden") ]
+        ]
+        [ section
+            [ id "todoapp" ]
+            [ lazy2 taskEntry address model.field
+            , lazy3 taskList address model.visibility model.tasks
+            , lazy3 controls address model.visibility model.tasks
+            ]
+        , infoFooter
+        ]
 
 
 onEnter : Address a -> a -> Attribute
@@ -157,7 +176,10 @@ onEnter address value =
 
 is13 : Int -> Result String ()
 is13 code =
-  if code == 13 then Ok () else Err "not the right key code"
+  if code == 13 then
+      Ok ()
+  else
+      Err "not the right key code"
 
 
 taskEntry : Address Action -> String -> Html
@@ -180,125 +202,140 @@ taskEntry address task =
 
 taskList : Address Action -> String -> List Task -> Html
 taskList address visibility tasks =
-    let isVisible todo =
+    let
+        isVisible todo =
             case visibility of
               "Completed" -> todo.completed
               "Active" -> not todo.completed
               "All" -> True
 
-        allCompleted = List.all .completed tasks
+        allCompleted =
+            List.all .completed tasks
 
-        cssVisibility = if List.isEmpty tasks then "hidden" else "visible"
+        cssVisibility =
+            if List.isEmpty tasks then
+                "hidden"
+            else
+                "visible"
     in
-    section
-      [ id "main"
-      , style [ ("visibility", cssVisibility) ]
-      ]
-      [ input
-          [ id "toggle-all"
-          , type' "checkbox"
-          , name "toggle"
-          , checked allCompleted
-          , onClick address (CheckAll (not allCompleted))
+        section
+          [ id "main"
+          , style [ ("visibility", cssVisibility) ]
           ]
-          []
-      , label
-          [ for "toggle-all" ]
-          [ text "Mark all as complete" ]
-      , ul
-          [ id "todo-list" ]
-          (List.map (todoItem address) (List.filter isVisible tasks))
-      ]
+          [ input
+              [ id "toggle-all"
+              , type' "checkbox"
+              , name "toggle"
+              , checked allCompleted
+              , onClick address (CheckAll (not allCompleted))
+              ]
+              []
+          , label
+              [ for "toggle-all" ]
+              [ text "Mark all as complete" ]
+          , ul
+              [ id "todo-list" ]
+              (List.map (todoItem address) (List.filter isVisible tasks))
+          ]
 
 
 todoItem : Address Action -> Task -> Html
 todoItem address todo =
     li
-      [ classList [ ("completed", todo.completed), ("editing", todo.editing) ] ]
-      [ div
-          [ class "view" ]
-          [ input
-              [ class "toggle"
-              , type' "checkbox"
-              , checked todo.completed
-              , onClick address (Check todo.id (not todo.completed))
-              ]
-              []
-          , label
-              [ onDoubleClick address (EditingTask todo.id True) ]
-              [ text todo.description ]
-          , button
-              [ class "destroy"
-              , onClick address (Delete todo.id)
-              ]
-              []
-          ]
-      , input
-          [ class "edit"
-          , value todo.description
-          , name "title"
-          , id ("todo-" ++ toString todo.id)
-          , on "input" targetValue (Signal.message address << UpdateTask todo.id)
-          , onBlur address (EditingTask todo.id False)
-          , onEnter address (EditingTask todo.id False)
-          ]
-          []
-      ]
+        [ classList [ ("completed", todo.completed), ("editing", todo.editing) ] ]
+        [ div
+            [ class "view" ]
+            [ input
+                [ class "toggle"
+                , type' "checkbox"
+                , checked todo.completed
+                , onClick address (Check todo.id (not todo.completed))
+                ]
+                []
+            , label
+                [ onDoubleClick address (EditingTask todo.id True) ]
+                [ text todo.description ]
+            , button
+                [ class "destroy"
+                , onClick address (Delete todo.id)
+                ]
+                []
+            ]
+        , input
+            [ class "edit"
+            , value todo.description
+            , name "title"
+            , id ("todo-" ++ toString todo.id)
+            , on "input" targetValue (Signal.message address << UpdateTask todo.id)
+            , onBlur address (EditingTask todo.id False)
+            , onEnter address (EditingTask todo.id False)
+            ]
+            []
+        ]
 
 
 controls : Address Action -> String -> List Task -> Html
 controls address visibility tasks =
-    let tasksCompleted = List.length (List.filter .completed tasks)
-        tasksLeft = List.length tasks - tasksCompleted
-        item_ = if tasksLeft == 1 then " item" else " items"
+    let
+        tasksCompleted =
+            List.length (List.filter .completed tasks)
+
+        tasksLeft =
+            List.length tasks - tasksCompleted
+
+        item_ =
+            if tasksLeft == 1 then
+                " item"
+            else
+                " items"
     in
-    footer
-      [ id "footer"
-      , hidden (List.isEmpty tasks)
-      ]
-      [ span
-          [ id "todo-count" ]
-          [ strong [] [ text (toString tasksLeft) ]
-          , text (item_ ++ " left")
-          ]
-      , ul
-          [ id "filters" ]
-          [ visibilitySwap address "#/" "All" visibility
-          , text " "
-          , visibilitySwap address "#/active" "Active" visibility
-          , text " "
-          , visibilitySwap address "#/completed" "Completed" visibility
-          ]
-      , button
-          [ class "clear-completed"
-          , id "clear-completed"
-          , hidden (tasksCompleted == 0)
-          , onClick address DeleteComplete
-          ]
-          [ text ("Clear completed (" ++ toString tasksCompleted ++ ")") ]
-      ]
+        footer
+            [ id "footer"
+            , hidden (List.isEmpty tasks)
+            ]
+            [ span
+                [ id "todo-count" ]
+                [ strong [] [ text (toString tasksLeft) ]
+                , text (item_ ++ " left")
+                ]
+            , ul
+                [ id "filters" ]
+                [ visibilitySwap address "#/" "All" visibility
+                , text " "
+                , visibilitySwap address "#/active" "Active" visibility
+                , text " "
+                , visibilitySwap address "#/completed" "Completed" visibility
+                ]
+            , button
+                [ class "clear-completed"
+                , id "clear-completed"
+                , hidden (tasksCompleted == 0)
+                , onClick address DeleteComplete
+                ]
+                [ text ("Clear completed (" ++ toString tasksCompleted ++ ")") ]
+            ]
 
 
 visibilitySwap : Address Action -> String -> String -> String -> Html
 visibilitySwap address uri visibility actualVisibility =
     li
-      [ onClick address (ChangeVisibility visibility) ]
-      [ a [ href uri, classList [("selected", visibility == actualVisibility)] ] [ text visibility ] ]
+        [ onClick address (ChangeVisibility visibility) ]
+        [ a [ href uri, classList [("selected", visibility == actualVisibility)] ] [ text visibility ] ]
 
 
 infoFooter : Html
 infoFooter =
     footer [ id "info" ]
-      [ p [] [ text "Double-click to edit a todo" ]
-      , p []
-          [ text "Written by "
-          , a [ href "https://github.com/evancz" ] [ text "Evan Czaplicki" ]
-          ]
-      , p []
-          [ text "Part of "
-          , a [ href "http://todomvc.com" ] [ text "TodoMVC" ]
-          ]
-      ]
+        [ p [] [ text "Double-click to edit a todo" ]
+        , p []
+            [ text "Written by "
+            , a [ href "https://github.com/evancz" ] [ text "Evan Czaplicki" ]
+            ]
+        , p []
+            [ text "Part of "
+            , a [ href "http://todomvc.com" ] [ text "TodoMVC" ]
+            ]
+        ]
 
 
 ---- INPUTS ----
@@ -306,34 +343,39 @@ infoFooter =
 -- wire the entire application together
 main : Signal Html
 main =
-  Signal.map (view actions.address) model
+    Signal.map (view actions.address) model
 
 
 -- manage the model of our application over time
 model : Signal Model
 model =
-  Signal.foldp update initialModel actions.signal
+    Signal.foldp update initialModel actions.signal
 
 
 initialModel : Model
 initialModel =
-  Maybe.withDefault emptyModel getStorage
+    Maybe.withDefault emptyModel getStorage
 
 
 -- actions from user input
 actions : Signal.Mailbox Action
 actions =
-  Signal.mailbox NoOp
+    Signal.mailbox NoOp
 
 
 port focus : Signal String
 port focus =
-    let needsFocus act =
+    let
+        needsFocus act =
             case act of
-              EditingTask id bool -> bool
-              _ -> False
+                EditingTask id bool ->
+                    bool
 
-        toSelector (EditingTask id _) = ("#todo-" ++ toString id)
+                _ ->
+                    False
+
+        toSelector (EditingTask id _) =
+            ("#todo-" ++ toString id)
     in
         actions.signal
           |> Signal.filter needsFocus (EditingTask 0 True)
@@ -344,4 +386,5 @@ port focus =
 port getStorage : Maybe Model
 
 port setStorage : Signal Model
-port setStorage = model
+port setStorage =
+    model


### PR DESCRIPTION
This is purely a whitespace change to bring this in line with the [official style guide](http://elm-lang.org/docs/style-guide):

* Consistently use four spaces for indentation. (Previously was 2 in some places and 4 in others.)
* Put a newline after the `=` in a declaration, except when declaring a union type.
* Put a newline after the `->` in a `case` expression.
* Put `if`...`then` on the same line.
* Give `let` and `in` their own lines.