### PR TITLE
stop exposing Html.Lazy.lazy

### DIFF
--- a/Todo.elm
+++ b/Todo.elm
@@ -19,7 +19,7 @@ http://elm-lang.org/learn/Architecture.elm
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Html.Lazy exposing (lazy, lazy2, lazy3)
+import Html.Lazy exposing (lazy2, lazy3)
 import Json.Decode as Json
 import Signal exposing (Signal, Address)
 import String


### PR DESCRIPTION
`Html.Lazy.lazy` is not used in `Todo.eml`