### PR TITLE
Changed outdated elm architecture link in the comments

### DIFF
--- a/Todo.elm
+++ b/Todo.elm
@@ -13,7 +13,7 @@ this in the Pong tutorial: http://elm-lang.org/blog/Pong.elm
 
 This program is not particularly large, so definitely see the following
 document for notes on structuring more complex GUIs with Elm:
-http://elm-lang.org/learn/Architecture.elm
+https://github.com/evancz/elm-architecture-tutorial/
 -}
 
 import Html exposing (..)
@@ -66,8 +66,8 @@ emptyModel =
 ---- UPDATE ----
 
 -- A description of the kinds of actions that can be performed on the model of
--- our application. See the following post for more info on this pattern and
--- some alternatives: http://elm-lang.org/learn/Architecture.elm
+-- our application. See the following tutorial for more info on this pattern and
+-- some alternatives: https://github.com/evancz/elm-architecture-tutorial/
 type Action
     = NoOp
     | UpdateField String


### PR DESCRIPTION
The link in the comments to http://elm-lang.org/learn/Architecture.elm returns a 404. I am not sure if what the correct link is. My guess is it is referencing the elm architecture tutorial: https://github.com/evancz/elm-architecture-tutorial/