### PR TITLE
Updated README.md to reflect current port behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ All of the Elm code lives in `Todo.elm` and relies on the [elm-lang/html][html] 
 
 [html]: http://package.elm-lang.org/packages/elm-lang/html/latest 
 
-There also is a port handler set up in `index.html` to set the focus on particular text fields when necessary.
+There also is a port handler set up in `index.html` to store the Elm application's state in `localStorage` on every update.
 
 
 ## Build Instructions


### PR DESCRIPTION
No longer set up a port in `index.html` to focus text fields